### PR TITLE
Bump chef gem to latest v11 to avoid issues with http body size differences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## Unreleased
 
+## [0.0.4] - 2015-09-03
+### Changed
+- bumped chef gem to version chef-11.18.12
+
 ## [0.0.3] - 2015-07-14
 ### Changed
 - updated sensu-plugin gem to 1.2.0

--- a/lib/sensu-plugins-chef/version.rb
+++ b/lib/sensu-plugins-chef/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsChef
   module Version
     MAJOR = 0
     MINOR = 0
-    PATCH = 3
+    PATCH = 4
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/sensu-plugins-chef.gemspec
+++ b/sensu-plugins-chef.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsChef::Version::VER_STRING
 
-  s.add_runtime_dependency 'chef',         '11.10.4'
+  s.add_runtime_dependency 'chef',         '11.18.12'
   s.add_runtime_dependency 'ridley',       '4.1.2'
   s.add_runtime_dependency 'sensu-plugin', '1.2.0'
 


### PR DESCRIPTION
bumping to latest v11 of chef gem "chef-11.18.12" I was seeing issueswith version 11.10.4 "Response body length <some_larger_num> does not match HTTP Content-Length header <some_num>" despite being able to converge with client. After investigation this is a common issue with that version and bumping to latest v11 fixed.

This error is an issue that was fixed in later versions.

Here is an example of it failing with the current gem:

```
Check failed to run: Response body length 2671 does not match HTTP Content-Length header 279., ["/var/lib/gems/1.9.1/gems/chef-11.10.4/lib/chef/http/validate_content_length.rb:88:in `validate'", "/var/lib/gems/1.9.1/gems/chef-11.10.4/lib/chef/http/validate_content_length.rb:56:in `handle_response'", "/var/lib/gems/1.9.1/gems/chef-11.10.4/lib/chef/http.rb:219:in `block in apply_response_middleware'", "/var/lib/gems/1.9.1/gems/chef-11.10.4/lib/chef/http.rb:218:in `each'", "/var/lib/gems/1.9.1/gems/chef-11.10.4/lib/chef/http.rb:218:in `inject'", "/var/lib/gems/1.9.1/gems/chef-11.10.4/lib/chef/http.rb:218:in `apply_response_middleware'", "/var/lib/gems/1.9.1/gems/chef-11.10.4/lib/chef/http.rb:139:in `request'", "/var/lib/gems/1.9.1/gems/chef-11.10.4/lib/chef/rest.rb:106:in `get'", "/var/lib/gems/1.9.1/gems/sensu-plugins-chef-0.0.3/bin/check-chef-nodes.rb:66:in `nodes_last_seen'", "/var/lib/gems/1.9.1/gems/sensu-plugins-chef-0.0.3/bin/check-chef-nodes.rb:95:in `any_node_stuck?'", "/var/lib/gems/1.9.1/gems/sensu-plugins-chef-0.0.3/bin/check-chef-nodes.rb:78:in `run'", "/var/lib/gems/1.9.1/gems/sensu-plugin-1.2.0/lib/sensu-plugin/cli.rb:56:in `block in <class:CLI>'"]
```

After bumping and installing the gem and installing I get the expected result:

```
ChefNodesStatusChecker CRITICAL: The following nodes cannot be provisioned: ip-10-55-250-75.us-west-2.compute.internal, ip-10-55-150-59.us-west-2.compute.internal, ip-10-55-150-140.us-west-2.compute.internal, ip-10-55-150-111.us-west-2.compute.internal, ip-10-55-150-225.us-west-2.compute.internal, ip-10-55-140-108.us-west-2.compute.internal, ip-10-55-140-166.us-west-2.compute.internal
```
