### PR TITLE
change the default time for chef client to be considered failed. closes #4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## Unreleased
+- changed default time before a check is deemed critical to 35 minutes to match the chef-client cookbook (30 min + 5 in splay + 3 for converge)
 
 ## [0.0.5] - 2015-11-24
 ### Added

--- a/bin/check-chef-nodes.rb
+++ b/bin/check-chef-nodes.rb
@@ -41,7 +41,7 @@ class ChefNodesStatusChecker < Sensu::Plugin::Check::CLI
          description: 'Amount of seconds after which node considered as stuck',
          short: '-t CRITICAL-TIMESPAN',
          long: '--timespan CRITICAL-TIMESPAN',
-         default: (600 + 300.0 + 60 * 3)
+         default: (1800 + 300.0 + 180)
 
   option :chef_server_url,
          description: 'URL of Chef server',


### PR DESCRIPTION
change default time to 35 minutes to match: https://github.com/chef-cookbooks/chef-client/blob/30255968f033dc4705b7bed81509b8ba6672c0ec/attributes/default.rb#L39-L40

related to: https://github.com/sensu-plugins/sensu-plugins-chef/issues/4#issuecomment-160857379
