### PR TITLE
Remove Ruby 1.9.3 support; add Ruby 2.3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ cache:
 install:
 - bundle install
 rvm:
-- 1.9.3
 - 2.0
 - 2.1
 - 2.2
+- 2.3.0
 notifications:
   email:
     recipients:
@@ -26,8 +26,8 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 1.9.3
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2
+    rvm: 2.3.0
     repo: sensu-plugins/sensu-plugins-chef

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-- check-chef-server.rb: loosen regex used to match chef-server-ctl status output
+
+### Added
 - check-chef-nodes.rb: add an option to "check-chef-nodes" to exclude nodes from check
+
+### Changed
+- check-chef-server.rb: loosen regex used to match chef-server-ctl status output
 - Rubocop updated to ~> 0.40; automated cleanup applied.
+
+### Removed
 - Remove Ruby 1.9.3 support; add Ruby 2.3.0 support
 
 ## [0.0.6] - 2015-12-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-- add an option to "check-chef-nodes" to exclude nodes from check
+- check-chef-server.rb: loosen regex used to match chef-server-ctl status output
+- check-chef-nodes.rb: add an option to "check-chef-nodes" to exclude nodes from check
+- Rubocop updated to ~> 0.40; automated cleanup applied.
+- Remove Ruby 1.9.3 support; add Ruby 2.3.0 support
 
 ## [0.0.6] - 2015-12-03
 ### Changed

--- a/sensu-plugins-chef.gemspec
+++ b/sensu-plugins-chef.gemspec
@@ -2,12 +2,8 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
+require 'sensu-plugins-chef'
 
-if RUBY_VERSION < '2.0.0'
-  require 'sensu-plugins-chef'
-else
-  require_relative 'lib/sensu-plugins-chef'
-end
 
 # pvt_key = '~/.ssh/gem-private_key.pem'
 
@@ -33,7 +29,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 1.9.3'
+  s.required_ruby_version  = '>= 2.0.0'
   # s.signing_key            = File.expand_path(pvt_key) if $PROGRAM_NAME =~ /gem\z/
   s.summary                = 'Sensu plugins for chef'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})

--- a/sensu-plugins-chef.gemspec
+++ b/sensu-plugins-chef.gemspec
@@ -2,8 +2,7 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
-require 'sensu-plugins-chef'
-
+require_relative 'lib/sensu-plugins-chef'
 
 # pvt_key = '~/.ssh/gem-private_key.pem'
 


### PR DESCRIPTION
## Pull Request Checklist
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
- [ ] Binstubs are created if needed
- [x] RuboCop passes
- [x] Existing tests pass 
#### Purpose

This PR removes Ruby 1.9.3 support, and adds support for testing under Ruby 2.3.0, per the Sensu Plugins policy: 

> Ruby 1.9.3 (EOL): Linting is not done against it, and 1.9.3 will be supported where possible till Feb 2016 which is one year after EOL and 2 years after EOL was announced.
#### Known Compatibility Issues

Adds incompatibility with Ruby version < 2.0.0
