### PR TITLE
chef-nodes-chef.rb requires a client name set:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 cache:
 - bundler
 install:
+- gem install bundler -v 1.12
 - bundle install
 rvm:
 - 2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ install:
 - gem install bundler -v 1.12
 - bundle install
 rvm:
-- 2.0
 - 2.1
 - 2.2
 - 2.3.0
@@ -27,7 +26,6 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 2.0
     rvm: 2.1
     rvm: 2.2
     rvm: 2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 - in `check-chef-nodes.rb` made client name required
 - in `check-chef-nodes.rb` made a sane default for client name
+- fix travis builds for ruby versions that have older bundler installed
 
 ## [2.0.0] - 2016-07-25
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- in `check-chef-nodes.rb` made client name required
+- in `check-chef-nodes.rb` made a sane default for client name
 
 ## [2.0.0] - 2016-07-25
 ### Changed

--- a/bin/check-chef-nodes.rb
+++ b/bin/check-chef-nodes.rb
@@ -49,10 +49,13 @@ class ChefNodesStatusChecker < Sensu::Plugin::Check::CLI
          short: '-U CHEF-SERVER-URL',
          long: '--url CHEF-SERVER-URL'
 
+  # defaults to the equivalent of `hostname --fqdn`
   option :client_name,
          description: 'Client name',
          short: '-C CLIENT-NAME',
-         long: '--client CLIENT-NAME'
+         long: '--client CLIENT-NAME',
+         required: true,
+         default: Socket.gethostbyname(Socket.gethostname).first
 
   option :key,
          description: 'Client\'s key',

--- a/bin/check-chef-server.rb
+++ b/bin/check-chef-server.rb
@@ -38,7 +38,7 @@ require 'sensu-plugin/check/cli'
 class CheckChefServer < Sensu::Plugin::Check::CLI
   def run
     # chef-server-ctl must be run with elevated privs. fail if we're not uid 0
-    if Process.uid != 0
+    if Process.uid.nonzero?
       unknown('check-chef-server must be run with elevated privileges so that chef-server-ctl can be executed')
     else
       status = `/usr/bin/chef-server-ctl status`

--- a/sensu-plugins-chef.gemspec
+++ b/sensu-plugins-chef.gemspec
@@ -31,14 +31,27 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsChef::Version::VER_STRING
 
-  s.add_runtime_dependency 'chef',         '12.12.15'
+  s.add_runtime_dependency 'chef', '12.12.15'
+  if defined?(RUBY_VERSION) && RUBY_VERSION <= '2.1'
+    s.add_development_dependency 'buff-ignore', '1.1.1'
+    s.add_runtime_dependency 'chef-zero', '~> 4.5.0'
+    s.add_runtime_dependency 'ffi-yajl', '~> 2.2.3'
+    s.add_runtime_dependency 'net-http-persistent', '~> 2.9'
+    s.add_runtime_dependency 'ohai', '~> 8.17.0'
+    s.add_runtime_dependency 'rack', '~> 1.6.5'
+  end
+
   s.add_runtime_dependency 'ridley',       '4.1.2'
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
-  s.add_runtime_dependency 'varia_model',  '0.4.1'
+  s.add_runtime_dependency 'varia_model', '0.4.1'
 
-  s.add_development_dependency 'bundler',                   '~> 1.12'
+  s.add_development_dependency 'bundler', '~> 1.12'
+
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   s.add_development_dependency 'github-markup',             '~> 1.3'
+  if defined?(RUBY_VERSION) && RUBY_VERSION <= '2.2.2'
+    s.add_development_dependency 'nio4r', '~> 1.2'
+  end
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.5'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'


### PR DESCRIPTION
- made it required as an option
- added a sane default of `hostname --fqdn`

fixed CI issues with rubocop and dependencies for specific ruby versions

relates to: #13

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 


#### Purpose

Basically the option was always required but it was not explicitly called out in option. Make a sane default of the hosts fqdn.

#### Known Compatablity Issues
This would be a breaking change other than the change in behavior will not really affect anyone negatively as you could not get it to work without using the value.