### PR TITLE
fixes #16 uninstialized constant in chef >= 12.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- fixed issue with uninitialized constant (@majormoses)
 
 ## [2.0.0] - 2017-02-12
 ### Added

--- a/bin/check-chef-node.rb
+++ b/bin/check-chef-node.rb
@@ -27,7 +27,7 @@
 #
 
 require 'sensu-plugin/check/cli'
-require 'chef'
+require 'chef/rest'
 
 class ChefNodeChecker < Sensu::Plugin::Check::CLI
   option :node_name,

--- a/bin/check-chef-nodes.rb
+++ b/bin/check-chef-nodes.rb
@@ -32,7 +32,7 @@
 #
 
 require 'sensu-plugin/check/cli'
-require 'chef'
+require 'chef/rest'
 
 #
 # Chef Nodes Status Checker


### PR DESCRIPTION
## Pull Request Checklist

fixes #16 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 


#### Purpose
Temporary workaround before rewriting in ridley to get past:
```
Check failed to run: uninitialized constant Chef::REST, ["./check-chef-nodes.rb:99:in chef_api_connection'", "./check-chef-nodes.rb:69:inconnection'", "./check-chef-nodes.rb:73:in nodes_last_seen'", "./check-chef-nodes.rb:103:inany_node_stuck?'", "./check-chef-nodes.rb:86:in run'", "/opt/sensu/embedded/lib/ruby/gems/2.2.0/gems/sensu-plugin-1.2.0/lib/sensu-plugin/cli.rb:56:inblock in class:CLI'"]
```
#### Known Compatablity Issues

