### PR TITLE
add a gracetime and ignore nodes that have no ohai data to prevent false positives during initial convergence

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 - [ ] RuboCop passes
 
-- [ ] Existing tests pass 
+- [ ] Existing tests pass
 
 #### New Plugins
 
@@ -24,5 +24,4 @@
 
 #### Purpose
 
-#### Known Compatablity Issues
-
+#### Known Compatibility Issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Breaking Change
+- check-chef-nodes.rb: added an option for a grace_period which allows exclusion of nodes until they have been online for a specified ammount of time. Defaulting to 300 seconds. (@majormoses)
+- check-chef-nodes.rb: when chef has not initially run we can not determine the time that it has been up for nor when it last converged as ohai will not have this information yet. Rather than assuming this is a failure we treat nodes that have no ohai data as not being able to be evaluated. If you are looking for something to catch nodes that fail initial bootstrap I would suggest something along the lines of [aws-watcher](https://github.com/majormoses/aws-watcher)  (@majormoses)
+
+
 ## [3.0.2] - 2017-05-28
 ## Fixed
 - updating runtime deps


### PR DESCRIPTION
Basically when a node is first spun up it checks the last convergence time which will be the epoch until it completes. To combat this we only check nodes that have had a certain amount of uptime as the data they return is unreliable otherwise.

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### Purpose
Basically when a node is first spun up it checks the last convergence time which will be the epoch until it completes. To combat this we only check nodes that have had a certain amount of uptime as the data they return is unreliable otherwise.

#### Known Compatibility Issues
None, though this is a breaking change. See changelog an purpose
