### PR TITLE
Fix CVE-2017-8418

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+AllCops:
+  Exclude:
+    - '**/Rakefile'
+    - '*.gemspec'
 
 MethodLength:
   Max: 200

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-AllCops:
+Style/BlockLength:
   Exclude:
     - '**/Rakefile'
     - '*.gemspec'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Security
+- updated `rubocop` dependency to `~> 0.51.0` per: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418. (@geewiz)
+
+### Breaking Change
+- in order to bring in new rubocop dependency we need to drop ruby 2.0 support as it is EOL and aligns with our support policy. (@majormoses)
+
+### Fixed
+- made exception handling more specific by catching StandardError
+
 ## [4.0.0] - 2017-08-14
 ### Breaking Change
 - check-chef-nodes.rb: added an option for a grace_period which allows exclusion of nodes until they have been online for a specified ammount of time. Defaulting to 300 seconds. (@majormoses)

--- a/Rakefile
+++ b/Rakefile
@@ -7,9 +7,9 @@ require 'yard'
 require 'yard/rake/yardoc_task'
 
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w().freeze
+  OTHER_PATHS = %w[].freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
-  t.options = %w(--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md)
+  t.options = %w[--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md]
 end
 
 RuboCop::RakeTask.new
@@ -35,4 +35,4 @@ task :check_binstubs do
   end
 end
 
-task default: [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
+task default: %i[spec make_bin_executable yard rubocop check_binstubs]

--- a/bin/check-chef-node.rb
+++ b/bin/check-chef-node.rb
@@ -71,7 +71,7 @@ class ChefNodeChecker < Sensu::Plugin::Check::CLI
     else
       warning "Node #{config[:node_name]} does not contain 'ohai_time' attribute"
     end
-  rescue => e
+  rescue StandardError => e
     critical "Node #{config[:node_name]} not found - #{e.message}"
   end
 

--- a/bin/check-chef-nodes.rb
+++ b/bin/check-chef-nodes.rb
@@ -74,9 +74,10 @@ class ChefNodesStatusChecker < Sensu::Plugin::Check::CLI
          default: '^$'
 
   option :grace_period,
-         description: 'The ammount of time before a node should be evaluated for failed convergence',
+         description: 'The amount of time before a node should be evaluated for failed convergence',
          long: '--grace-period SECONDS',
-         default: (60 * 5), # default 5 minutes, which seems like a good but not great default
+         # default 5 minutes, which seems like a good but not great default
+         default: (60 * 5),
          proc: proc(&:to_i)
 
   option :ignore_ssl_verification,

--- a/bin/handler-chef-node.rb
+++ b/bin/handler-chef-node.rb
@@ -75,7 +75,7 @@ class ChefNode < Sensu::Handler
         puts "CHEF-NODE: Ridley is broken: #{error.inspect}"
         true
       end
-    rescue => error
+    rescue StandardError => error
       puts "CHEF-NODE: Unexpected error: #{error.inspect}"
       true
     end
@@ -84,7 +84,7 @@ class ChefNode < Sensu::Handler
   def delete_sensu_client!
     api_request(:DELETE, '/clients/' + @event['client']['name'])
     puts "CHEF-NODE: Successfully deleted Sensu client #{@event['client']['name']}"
-  rescue => error
+  rescue StandardError => error
     puts "CHEF-NODE: Unexpected error: #{error.inspect}"
   end
 

--- a/sensu-plugins-chef.gemspec
+++ b/sensu-plugins-chef.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.5'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
-  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
+  s.add_development_dependency 'rubocop',                   '~> 0.51.0'
   s.add_development_dependency 'rspec',                     '~> 3.4'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end

--- a/sensu-plugins-chef.gemspec
+++ b/sensu-plugins-chef.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
                               stale Sensu clients'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md CHANGELOG.md]
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-chef'
   s.license                = 'MIT'
   s.metadata               = { 'maintainer'         => 'sensu-plugin',
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.5'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
-  s.add_development_dependency 'rubocop',                   '~> 0.51.0'
   s.add_development_dependency 'rspec',                     '~> 3.4'
+  s.add_development_dependency 'rubocop',                   '~> 0.51.0'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

Yes: https://github.com/sensu-plugins/community/issues/77

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

A security flaw in rubocop requires an update of the gem. This change upgrades rubocop to 0.51.0 and makes a few necessary style changes.

#### Known Compatibility Issues

Apparently, newer rubocop versions drop support for Ruby 2.0, making this a breaking change.